### PR TITLE
feat: add dbr official demo to samples list

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,6 @@ Get the basic features of the library working with plain/native JavaScript or wi
 ### Others
 
 * [**Debug**](https://github.com/Dynamsoft/barcode-reader-javascript-samples/tree/main/others/debug#readme): Collect the actual image frames for debugging purposes.
+
+### Official Online Demo
+- [**Official Online Demo**](https://demo.dynamsoft.com/barcode-reader-js): Official demo for Dynamsoft Barcode Reader JavaScript Edition (written in Vue). Take our barcode scanner demo and see how it works in different modes!

--- a/index.html
+++ b/index.html
@@ -159,6 +159,10 @@
                     <a class="github" href="https://github.com/Dynamsoft/barcode-reader-javascript-samples/tree/main/others/debug" title="Check code on GitHub"></a>
                 </div>
             </div>
+            <div class="file"><a data-balloon-length="fit" data-balloon-pos="up" aria-label="Official demo for Dynamsoft Barcode Reader JavaScript Edition" class="button title" href="https://demo.dynamsoft.com/barcode-reader-js/" target="_blank">Official Online Demo</a>
+                <span id="icon051" class="tooltipIcon"></span>
+                <a class="github" href="https://github.com/Dynamsoft/barcode-reader-javascript-demo" title="Check code on GitHub"></a>
+            </div>
         </div>
 </body>
 <style>


### PR DESCRIPTION
# Issue
Sample list doesn't match the list of https://www.dynamsoft.com/barcode-reader/docs/web/programming/javascript/samples-demos/index.html

# Solution
Add Official online demo to the samples list on the `README` and on the `index.html`

# Screenshots
![image](https://github.com/Dynamsoft/barcode-reader-javascript-samples/assets/43778377/a2ba9261-e44f-4b46-9f51-fef27ac2a63d)

![image](https://github.com/Dynamsoft/barcode-reader-javascript-samples/assets/43778377/df2e8dbc-9ae5-4b70-acbe-3db24e3b76ee)
