### PR TITLE
fix: exact installation in docs, buttons-container class, and white-space for `VideoCapture`

### DIFF
--- a/hello-world/angular/README.md
+++ b/hello-world/angular/README.md
@@ -57,7 +57,7 @@ Below is the configuration used for this sample.
 
 ```cmd
 cd my-app
-npm install dynamsoft-barcode-reader-bundle
+npm install dynamsoft-barcode-reader-bundle -E
 ```
 
 ## Start to implement

--- a/hello-world/angular/README.md
+++ b/hello-world/angular/README.md
@@ -348,7 +348,7 @@ export class ImageCaptureComponent {
   <div class='title'>
     <h2 class='title-text'>Hello World for Angular</h2>
   </div>
-  <div class='top-btns'>
+  <div class='buttons-container'>
     <button (click)="switchMode('video')" [ngStyle]="{'background-color': mode === 'video' ? 'rgb(255,174,55)' : 'white'}">Decode Video</button>
     <button (click)="switchMode('image')" [ngStyle]="{'background-color': mode === 'image' ? 'rgb(255,174,55)' : 'white'}">Decode Image</button>
   </div>

--- a/hello-world/angular/src/app/app.component.css
+++ b/hello-world/angular/src/app/app.component.css
@@ -4,30 +4,30 @@
   align-items: center;
   margin-top: 20px;
 }
-.top-btns {
+.buttons-container {
   width: 30%;
   margin: 20px auto;
 }
-.top-btns button {
+.buttons-container button {
   display: inline-block;
   border: 1px solid black;
   padding: 5px 15px;
   background-color: transparent;
   cursor: pointer;
 }
-.top-btns button:first-child {
+.buttons-container button:first-child {
   border-top-left-radius: 10px;
   border-bottom-left-radius: 10px;
   border-right: transparent;
 }
-.top-btns button:nth-child(2) {
+.buttons-container button:nth-child(2) {
   border-top-right-radius: 10px;
   border-bottom-right-radius: 10px;
   border-left: transparent;
 }
 
 @media screen and (max-width: 800px) {
-  .top-btns {
+  .buttons-container {
     width: 70%;
   }
 }

--- a/hello-world/angular/src/app/app.component.html
+++ b/hello-world/angular/src/app/app.component.html
@@ -2,7 +2,7 @@
   <div class='title'>
     <h2 class='title-text'>Hello World for Angular</h2>
   </div>
-  <div class='top-btns'>
+  <div class='buttons-container'>
     <button (click)="switchMode('video')" [ngStyle]="{'background-color': mode === 'video' ? 'rgb(255,174,55)' : 'white'}">Decode Video</button>
     <button (click)="switchMode('image')" [ngStyle]="{'background-color': mode === 'image' ? 'rgb(255,174,55)' : 'white'}">Decode Image</button>
   </div>

--- a/hello-world/angular/src/app/video-capture/video-capture.component.css
+++ b/hello-world/angular/src/app/video-capture/video-capture.component.css
@@ -7,4 +7,5 @@
   width: 100%;
   height: 10vh;
   overflow: auto;
+  white-space: pre-wrap;
 }

--- a/hello-world/es6.html
+++ b/hello-world/es6.html
@@ -13,7 +13,7 @@
     <h1>Hello World for ES6 (Decode via Camera)</h1>
     <div id="camera-view-container" style="width: 100%; height: 80vh"></div>
     Results:<br />
-    <div id="results" style="width: 100%; height: 10vh; overflow: auto"></div>
+    <div id="results" style="width: 100%; height: 10vh; overflow: auto; white-space: pre-wrap"></div>
     <script type="module">
       import {
         CoreModule,

--- a/hello-world/hello-world.html
+++ b/hello-world/hello-world.html
@@ -13,7 +13,7 @@
     <h1>Hello World (Decode via Camera)</h1>
     <div id="camera-view-container" style="width: 100%; height: 80vh"></div>
     Results:<br />
-    <div id="results" style="width: 100%; height: 10vh; overflow: auto"></div>
+    <div id="results" style="width: 100%; height: 10vh; overflow: auto; white-space: pre-wrap"></div>
     <script src="https://cdn.jsdelivr.net/npm/dynamsoft-barcode-reader-bundle@10.2.1000/dist/dbr.bundle.js"></script>
     <script>
       /** LICENSE ALERT - README

--- a/hello-world/next/README.md
+++ b/hello-world/next/README.md
@@ -59,7 +59,7 @@ Below is the configuration used for this sample.
 
 ```cmd
 cd my-app
-npm install dynamsoft-barcode-reader-bundle
+npm install dynamsoft-barcode-reader-bundle -E
 ```
 
 ## Start to implement
@@ -421,3 +421,7 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+
+## Support
+
+If you have any questions, feel free to [contact Dynamsoft Support](https://www.dynamsoft.com/company/contact?utm_source=sampleReadme).

--- a/hello-world/next/components/VideoCapture/VideoCapture.css
+++ b/hello-world/next/components/VideoCapture/VideoCapture.css
@@ -8,4 +8,5 @@
   width: 100%;
   height: 10vh;
   overflow: auto;
+  white-space: pre-wrap;
 }

--- a/hello-world/nuxt/README.md
+++ b/hello-world/nuxt/README.md
@@ -102,7 +102,7 @@ CoreModule.loadWasm(["DBR"]);
 
 ### Edit the `VideoCapture` component
 
-* In `VideoCapture.client.vue`, add code for initializing and destroying some instances. The `VideoCapture` component helps decode barcodes via camera.
+* In `VideoCapture.client.vue`, add code for initializing and destroying some instances. The `VideoCapture` component helps decode barcodes via camera.  For our stylesheet (CSS) specification, please refer to our [source code](#Official-Sample).
 
 ```vue
 <!-- /components/VideoCapture.client.vue -->
@@ -196,29 +196,6 @@ onBeforeUnmount(async () => {
   } catch (_) { }
 });
 </script>
-
-<template>
-  <div>
-    <div ref="cameraViewContainer" class="camera-view-container"></div>
-    <br />
-    Results:
-    <div ref="resultsContainer" class="results"></div>
-  </div>
-</template>
-
-<style scoped>
-.camera-view-container {
-  width: 100%;
-  height: 70vh;
-  background: #eee;
-}
-
-.results {
-  width: 100%;
-  height: 10vh;
-  overflow: auto;
-}
-</style>
 ```
 > Note:
 >
@@ -226,7 +203,7 @@ onBeforeUnmount(async () => {
 
 ### Edit the `ImageCapture` component
 
-* In `ImageCapture.client.vue`, add code for initializing and destroying the `CaptureVisionRouter` instance. The `ImageCapture` helps decode barcodes in an image.
+* In `ImageCapture.client.vue`, add code for initializing and destroying the `CaptureVisionRouter` instance. The `ImageCapture` helps decode barcodes in an image.  For our stylesheet (CSS) specification, please refer to our [source code](#Official-Sample).
 
 ```vue
 <!-- /components/ImageCapture.client.vue -->
@@ -296,35 +273,13 @@ onBeforeUnmount(async () => {
     <div class="results" ref="resultContainer"></div>
   </div>
 </template>
-
-<style scoped>
-.image-capture-container {
-  width: 100%;
-  height: 100%;
-  font-family: Consolas, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace;
-}
-
-.image-capture-container .input-container {
-  width: 80%;
-  height: 100%;
-  display: flex;
-  justify-content: center;
-  border: 1px solid black;
-  margin: 0 auto;
-}
-
-.image-capture-container .results {
-  margin-top: 20px;
-  height: 100%;
-}
-</style>
 ```
 
 ### Add `VideoCapture` and `ImageCapture` components in `app.vue`
 
 * On `/app.vue`, we will edit the component so that it offers buttons to switch components between `VideoCapture` and `ImageCapture`.
 
-* Add following code to `app.vue`.
+* Add following code to `app.vue`.  For our stylesheet (CSS) specification, please refer to our [source code](#Official-Sample).
 
 ```vue
 <!-- /app.vue -->
@@ -333,7 +288,7 @@ onBeforeUnmount(async () => {
     <div class='title'>
       <h2 class='title-text'>Hello World for NuxtJS</h2>
     </div>
-    <div class='top-btns'>
+    <div class='buttons-container'>
       <button @click="mode = 'video'"
         :style="{ backgroundColor: mode === 'video' ? 'rgb(255, 174, 55)' : '#FFFFFF' }">Video Capture</button>
       <button @click="mode = 'image'"
@@ -355,34 +310,6 @@ import ImageCapture from "./components/ImageCapture.client.vue";
 
 const mode: Ref<string> = ref("video");
 </script>
-
-<style scoped>
-.title {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  margin-top: 20px;
-}
-
-.top-btns {
-  width: 30%;
-  margin: 20px auto;
-}
-
-.top-btns button {
-  display: inline-block;
-  border: 1px solid black;
-  padding: 5px 15px;
-  background-color: transparent;
-  cursor: pointer;
-}
-
-@media screen and (max-width: 800px) {
-  .top-btns {
-    width: 70%;
-  }
-}
-</style>
 ```
 > Note: 
 >

--- a/hello-world/nuxt/README.md
+++ b/hello-world/nuxt/README.md
@@ -47,7 +47,7 @@ You will be asked to configure quite a few things for the application during the
 
 ```cmd
 cd my-app
-npm install dynamsoft-barcode-reader-bundle
+npm install dynamsoft-barcode-reader-bundle -E
 ```
 
 ## Start to implement

--- a/hello-world/nuxt/app.vue
+++ b/hello-world/nuxt/app.vue
@@ -4,7 +4,7 @@
       <h2 class='title-text'>Hello World for NuxtJS</h2>
       <img class='title-logo' src="./assets/logo.svg" alt="logo" />
     </div>
-    <div class='top-btns'>
+    <div class='buttons-container'>
       <button @click="mode = 'video'"
         :style="{ backgroundColor: mode === 'video' ? 'rgb(255, 174, 55)' : '#FFFFFF' }">Video Capture</button>
       <button @click="mode = 'image'"
@@ -41,12 +41,12 @@ const mode: Ref<string> = ref("video");
   margin-left: 10px;
 }
 
-.top-btns {
+.buttons-container {
   width: 30%;
   margin: 20px auto;
 }
 
-.top-btns button {
+.buttons-container button {
   display: inline-block;
   border: 1px solid black;
   padding: 5px 15px;
@@ -54,20 +54,20 @@ const mode: Ref<string> = ref("video");
   cursor: pointer;
 }
 
-.top-btns button:first-child {
+.buttons-container button:first-child {
   border-top-left-radius: 10px;
   border-bottom-left-radius: 10px;
   border-right: transparent;
 }
 
-.top-btns button:nth-child(2) {
+.buttons-container button:nth-child(2) {
   border-top-right-radius: 10px;
   border-bottom-right-radius: 10px;
   border-left: transparent;
 }
 
 @media screen and (max-width: 800px) {
-  .top-btns {
+  .buttons-container {
     width: 70%;
   }
 }

--- a/hello-world/nuxt/components/VideoCapture.client.vue
+++ b/hello-world/nuxt/components/VideoCapture.client.vue
@@ -109,5 +109,6 @@ onBeforeUnmount(async () => {
   width: 100%;
   height: 10vh;
   overflow: auto;
+  white-space: pre-wrap;
 }
 </style>

--- a/hello-world/nuxt/dynamsoft.config.ts
+++ b/hello-world/nuxt/dynamsoft.config.ts
@@ -17,10 +17,7 @@ CoreModule.engineResourcePaths = {
  * To use the library, you need to first specify a license key using the API "initLicense()" as shown below.
  */
 
-LicenseManager.initLicense(
-  "DLS2eyJoYW5kc2hha2VDb2RlIjoiMTAyODk0NDUwLVRYbFhaV0pRY205cSIsIm1haW5TZXJ2ZXJVUkwiOiJodHRwczovL21sdHMuZHluYW1zb2Z0LmNvbSIsIm9yZ2FuaXphdGlvbklEIjoiMTAyODk0NDUwIiwic3RhbmRieVNlcnZlclVSTCI6Imh0dHBzOi8vc2x0cy5keW5hbXNvZnQuY29tIiwiY2hlY2tDb2RlIjoxMDUxNjY0NjUyfQ==",
-  true
-);
+LicenseManager.initLicense("DLS2eyJvcmdhbml6YXRpb25JRCI6IjIwMDAwMSJ9", true);
 
 /**
  * You can visit https://www.dynamsoft.com/customer/license/trialLicense?utm_source=github&product=dbr&package=js to get your own trial license good for 30 days.

--- a/hello-world/react-hooks/README.md
+++ b/hello-world/react-hooks/README.md
@@ -45,7 +45,7 @@ npx create-react-app my-app --template typescript
 
 ```cmd
 cd my-app
-npm install dynamsoft-barcode-reader-bundle
+npm install dynamsoft-barcode-reader-bundle -E
 ```
 
 ## Start to implement

--- a/hello-world/react-hooks/src/components/VideoCapture/VideoCapture.css
+++ b/hello-world/react-hooks/src/components/VideoCapture/VideoCapture.css
@@ -7,4 +7,5 @@
   width: 100%;
   height: 10vh;
   overflow: auto;
+  white-space: pre-wrap;
 }

--- a/hello-world/react/README.md
+++ b/hello-world/react/README.md
@@ -45,7 +45,7 @@ npx create-react-app my-app --template typescript
 
 ```cmd
 cd my-app
-npm install dynamsoft-barcode-reader-bundle
+npm install dynamsoft-barcode-reader-bundle -E
 ```
 
 ## Start to implement

--- a/hello-world/react/src/components/VideoCapture/VideoCapture.css
+++ b/hello-world/react/src/components/VideoCapture/VideoCapture.css
@@ -7,4 +7,5 @@
   width: 100%;
   height: 10vh;
   overflow: auto;
+  white-space: pre-wrap;
 }

--- a/hello-world/requirejs.html
+++ b/hello-world/requirejs.html
@@ -15,7 +15,7 @@
     <div id="camera-view-container" style="width: 100%; height: 80vh"></div>
     Results:
     <br />
-    <div id="results" style="width: 100%; height: 10vh; overflow: auto"></div>
+    <div id="results" style="width: 100%; height: 10vh; overflow: auto; white-space: pre-wrap"></div>
     <script>
       requirejs(
         ["https://cdn.jsdelivr.net/npm/dynamsoft-barcode-reader-bundle@10.2.1000/dist/dbr.bundle.js"],

--- a/hello-world/vue/README.md
+++ b/hello-world/vue/README.md
@@ -60,8 +60,8 @@ Below is the configuration used for this sample.
 ### **CD** to the root directory of the application and install necessary libraries
 
 ```cmd
-npm install
-npm install dynamsoft-barcode-reader-bundle
+cd vue-project
+npm install dynamsoft-barcode-reader-bundle -E
 ```
 
 ## Start to implement
@@ -69,6 +69,7 @@ npm install dynamsoft-barcode-reader-bundle
 ### Add file "dynamsoft.config.ts" under "/src/" to configure libraries
 
 ```typescript
+/* /src/dynamsoft.config.ts */
 import { CoreModule } from "dynamsoft-core";
 import { LicenseManager } from "dynamsoft-license";
 import "dynamsoft-barcode-reader";
@@ -110,7 +111,7 @@ CoreModule.loadWasm(["DBR"]);
 
 * Create `VideoCapture.vue` under `/components/`. The VideoCapture component helps decode barcodes via camera.
 
-* In `VideoCapture.vue`, add the following code for initializing and destroying some instances.
+* In `VideoCapture.vue`, add the following code for initializing and destroying some instances. For our stylesheet (CSS) specification, please refer to our [source code](#Official-Sample).
 
 ```vue
 <!-- /src/components/VideoCapture.vue -->
@@ -213,20 +214,6 @@ onBeforeUnmount(async () => {
     <div ref="resultsContainer" class="results"></div>
   </div>
 </template>
-
-<style scoped>
-.camera-view-container {
-  width: 100%;
-  height: 70vh;
-  background: #eee;
-}
-
-.results {
-  width: 100%;
-  height: 10vh;
-  overflow: auto;
-}
-</style>
 ```
 > Note:
 >
@@ -236,7 +223,7 @@ onBeforeUnmount(async () => {
 
 * Create `ImageCapture.vue` under `/components/`. The `ImageCapture` component helps decode barcodes in an image.
 
-* In `ImageCapture.vue`, add code for initializing and destroying `CaptureVisionRouter` instance.
+* In `ImageCapture.vue`, add code for initializing and destroying `CaptureVisionRouter` instance. For our stylesheet (CSS) specification, please refer to our [source code](#Official-Sample).
 
 ```vue
 <!-- /src/components/ImageCapture.vue -->
@@ -306,41 +293,18 @@ onBeforeUnmount(async () => {
     <div class="results" ref="resultContainer"></div>
   </div>
 </template>
-
-<style scoped>
-.image-capture-container {
-  width: 100%;
-  height: 100%;
-  font-family: Consolas, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace;
-}
-
-.image-capture-container .input-container {
-  width: 80%;
-  height: 100%;
-  display: flex;
-  justify-content: center;
-  border: 1px solid black;
-  margin: 0 auto;
-}
-
-.image-capture-container .results {
-  margin-top: 20px;
-  height: 100%;
-}
-</style>
 ```
 
 ### Add the `VideoCapture` and `ImageCapture` component to `App.vue`
 
 * On `/src/App.vue`, we will edit the component so that it offers buttons to switch components between `VideoCapture` and `ImageCapture`.
 
-* Add following code to `App.vue`.
+* Add following code to `App.vue`. For our stylesheet (CSS) specification, please refer to our [source code](#Official-Sample).
 
 ```vue
 <!-- /src/App.vue -->
 <script setup lang="ts">
 import { ref, type Ref } from "vue";
-import vueLogo from "./assets/logo.svg";
 import VideoCapture from "./components/VideoCapture.vue";
 import ImageCapture from "./components/ImageCapture.vue";
 
@@ -352,9 +316,8 @@ const mode: Ref<string> = ref("video");
   <div class='App'>
     <div class='title'>
       <h2 class='title-text'>Hello World for Vue</h2>
-      <img class='title-logo' :src="vueLogo" alt="logo" />
     </div>
-    <div class='top-btns'>
+    <div class='buttons-container'>
       <button @click="mode = 'video'"
         :style="{ backgroundColor: mode === 'video' ? 'rgb(255, 174, 55)' : '#FFFFFF' }">Decode Video</button>
       <button @click="mode = 'image'"
@@ -364,40 +327,6 @@ const mode: Ref<string> = ref("video");
     <ImageCapture v-else />
   </div>
 </template>
-
-<style scoped>
-.title {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  margin-top: 20px;
-}
-
-.title .title-logo {
-  width: 30px;
-  height: 30px;
-  margin-left: 10px;
-}
-
-.top-btns {
-  width: 30%;
-  margin: 20px auto;
-}
-
-.top-btns button {
-  display: inline-block;
-  border: 1px solid black;
-  padding: 5px 15px;
-  background-color: transparent;
-  cursor: pointer;
-}
-
-@media screen and (max-width: 800px) {
-  .top-btns {
-    width: 70%;
-  }
-}
-</style>
 ```
 > Note:
 >

--- a/hello-world/vue/src/App.vue
+++ b/hello-world/vue/src/App.vue
@@ -14,7 +14,7 @@ const mode: Ref<string> = ref("video");
       <h2 class='title-text'>Hello World for Vue</h2>
       <img class='title-logo' :src="vueLogo" alt="logo" />
     </div>
-    <div class='top-btns'>
+    <div class='buttons-container'>
       <button @click="mode = 'video'"
         :style="{ backgroundColor: mode === 'video' ? 'rgb(255, 174, 55)' : '#FFFFFF' }">Decode Video</button>
       <button @click="mode = 'image'"
@@ -39,12 +39,12 @@ const mode: Ref<string> = ref("video");
   margin-left: 10px;
 }
 
-.top-btns {
+.buttons-container {
   width: 30%;
   margin: 20px auto;
 }
 
-.top-btns button {
+.buttons-container button {
   display: inline-block;
   border: 1px solid black;
   padding: 5px 15px;
@@ -52,20 +52,20 @@ const mode: Ref<string> = ref("video");
   cursor: pointer;
 }
 
-.top-btns button:first-child {
+.buttons-container button:first-child {
   border-top-left-radius: 10px;
   border-bottom-left-radius: 10px;
   border-right: transparent;
 }
 
-.top-btns button:nth-child(2) {
+.buttons-container button:nth-child(2) {
   border-top-right-radius: 10px;
   border-bottom-right-radius: 10px;
   border-left: transparent;
 }
 
 @media screen and (max-width: 800px) {
-  .top-btns {
+  .buttons-container {
     width: 70%;
   }
 }

--- a/hello-world/vue/src/components/VideoCapture.vue
+++ b/hello-world/vue/src/components/VideoCapture.vue
@@ -109,5 +109,6 @@ onBeforeUnmount(async () => {
   width: 100%;
   height: 10vh;
   overflow: auto;
+  white-space: pre-wrap;
 }
 </style>


### PR DESCRIPTION
- Add `-E` flag for exact installation
- Changed `top-btns` to `buttons-container`
- Add `white-space: pre-wrap` css for results on `VideoCapture` incase there's multiple barcodes being read on other `CaptureVisionTemplates` preset such as `ReadBarcodes_ReadrateFirst`