### PR TITLE
fix: broken demo links on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ Get the basic features of the library working with plain/native JavaScript or wi
 
 * [**Hello World**](https://demo.dynamsoft.com/samples/dbr/js/hello-world/hello-world.html?utm_source=sampleReadme): Scan barcodes from video stream with minimum code in JavaScript.
 * [**Read an Image**](https://demo.dynamsoft.com/samples/dbr/js/hello-world/read-an-image.html?utm_source=sampleReadme): Decode barcodes from images in mobile album or desktop file system.
-* [**Hello World in Angular**](https://demo.dynamsoft.com/samples/dbr/js/hello-world/angular/dist/angular?utm_source=sampleReadme): Read barcodes from camera and images in an Angular application.
-* [**Hello World in React**](https://demo.dynamsoft.com/samples/dbr/js/hello-world/react/build/?utm_source=sampleReadme): Read barcodes from camera and images in a React application.
-* [**Hello World in React using Hooks**](https://demo.dynamsoft.com/samples/dbr/js/hello-world/react-hooks/build/?utm_source=sampleReadme): Read barcodes from camera and images in a React application and use the Hooks charactor of React.
-* [**Hello World in Vue**](https://demo.dynamsoft.com/samples/dbr/js/hello-world/vue/dist/?utm_source=sampleReadme): Read barcodes from camera and images in a Vue 3 application.
+* [**Hello World in Angular**](https://github.com/Dynamsoft/barcode-reader-javascript-samples/tree/main/hello-world/angular#readme): Read barcodes from camera and images in an Angular application.
+* [**Hello World in React**](https://github.com/Dynamsoft/barcode-reader-javascript-samples/tree/main/hello-world/react#readme): Read barcodes from camera and images in a React application.
+* [**Hello World in React using Hooks**](https://github.com/Dynamsoft/barcode-reader-javascript-samples/tree/main/hello-world/react-hook#readme): Read barcodes from camera and images in a React application and use the Hooks charactor of React.
+* [**Hello World in Vue**](https://github.com/Dynamsoft/barcode-reader-javascript-samples/tree/main/hello-world/vue#readme): Read barcodes from camera and images in a Vue 3 application.
 * [**Hello World in Next.js**](https://github.com/Dynamsoft/barcode-reader-javascript-samples/tree/main/hello-world/next#readme): Read barcodes from camera and images in a Next.js application.
 * [**Hello World in Nuxt**](https://github.com/Dynamsoft/barcode-reader-javascript-samples/tree/main/hello-world/nuxt#readme): Read barcodes from camera and images in a Nuxt application.
 * [**Hello World in Electron**](https://github.com/Dynamsoft/barcode-reader-javascript-samples/tree/main/hello-world/electron#readme): Read barcodes from camera and images in a Electron application.
@@ -37,8 +37,9 @@ Get the basic features of the library working with plain/native JavaScript or wi
 ### Use Cases
 
 * [**Read Video and Fill a Form**](https://demo.dynamsoft.com/samples/dbr/js/use-case/fill-a-form-with-barcode-reading.html?utm_source=sampleReadme): Read barcodes to fill a form.
-* [**Read a Driver's License**](https://demo.dynamsoft.com/samples/dbr/js/use-case/read-a-drivers-license.html?utm_source=sampleReadme): Read the PDF417 barcode on a driver's license (AAMVA compliant) and parse it.
+* [**Read a Driver's License**](https://demo.dynamsoft.com/samples/dbr/js/use-case/read-a-drivers-license/index.html?utm_source=sampleReadme): Read the PDF417 barcode on a driver's license (AAMVA compliant) and parse it.
 * [**Show Result Texts on the Video**](https://demo.dynamsoft.com/samples/dbr/js/use-case/show-result-texts-on-the-video.html?utm_source=sampleReadme): Read barcodes via camera and show result texts on the video.
+* [**Locate an Item with Barcode**](https://demo.dynamsoft.com/samples/dbr/js/use-case/locate-an-item-with-barcode/index.html?utm_source=sampleReadme): Find a specific item in a large collection by scanning its unique barcode
 
 ### Others
 


### PR DESCRIPTION
Closes #195 

- Links from frameworks demo will be moved to the GitHub folder README.
- Fixed demo link for `Driver License` demo
- Added `Locate an Item with Barcodes` demo to Readme.