### PR TITLE
fix: Locate Item Sample - license text color, and mobile viewport

### DIFF
--- a/use-case/locate-an-item-with-barcode/index.html
+++ b/use-case/locate-an-item-with-barcode/index.html
@@ -22,6 +22,9 @@
         overscroll-behavior-y: none;
         overflow: hidden;
       }
+      .dls-license-msg-content {
+        color: black;
+      }
       #inputs-container {
         margin: 2rem;
         padding-bottom: 2rem;
@@ -99,6 +102,7 @@
         padding: 0.5rem;
         font-size: 1rem;
         overflow: hidden;
+        max-width: 10rem;
       }
       #camera-view-title {
         text-align: center;
@@ -197,6 +201,9 @@
         select,
         button {
           font-size: 1.5rem;
+        }
+        #select-camera-dropdown {
+          max-width: unset;
         }
       }
     </style>


### PR DESCRIPTION
Fix license text color being white
Fix Camera Dropdown pushing the back button