### PR TITLE
fix: patch for engineResourcePath for es6 and requirejs

### DIFF
--- a/hello-world/es6.html
+++ b/hello-world/es6.html
@@ -36,7 +36,15 @@
        * LICENSE ALERT - THE END
        */
 
-      CoreModule.engineResourcePaths.rootDirectory = "https://cdn.jsdelivr.net/npm/";
+      CoreModule.engineResourcePaths = {
+        std: "https://cdn.jsdelivr.net/npm/dynamsoft-capture-vision-std@1.4.10/dist/",
+        dip: "https://cdn.jsdelivr.net/npm/dynamsoft-image-processing@2.4.20/dist/",
+        core: "https://cdn.jsdelivr.net/npm/dynamsoft-core@3.4.20/dist/",
+        license: "https://cdn.jsdelivr.net/npm/dynamsoft-license@3.4.20/dist/",
+        cvr: "https://cdn.jsdelivr.net/npm/dynamsoft-capture-vision-router@2.4.20/dist/",
+        dbr: "https://cdn.jsdelivr.net/npm/dynamsoft-barcode-reader@10.4.20/dist/",
+        dce: "https://cdn.jsdelivr.net/npm/dynamsoft-camera-enhancer@4.1.0/dist/",
+      };
 
       // Optional. Used to load wasm resources in advance, reducing latency between video playing and barcode decoding.
       CoreModule.loadWasm(["DBR"]);

--- a/hello-world/requirejs.html
+++ b/hello-world/requirejs.html
@@ -39,7 +39,15 @@
            * LICENSE ALERT - THE END
            */
 
-          CoreModule.engineResourcePaths.rootDirectory = "https://cdn.jsdelivr.net/npm/";
+          CoreModule.engineResourcePaths = {
+            std: "https://cdn.jsdelivr.net/npm/dynamsoft-capture-vision-std@1.4.10/dist/",
+            dip: "https://cdn.jsdelivr.net/npm/dynamsoft-image-processing@2.4.20/dist/",
+            core: "https://cdn.jsdelivr.net/npm/dynamsoft-core@3.4.20/dist/",
+            license: "https://cdn.jsdelivr.net/npm/dynamsoft-license@3.4.20/dist/",
+            cvr: "https://cdn.jsdelivr.net/npm/dynamsoft-capture-vision-router@2.4.20/dist/",
+            dbr: "https://cdn.jsdelivr.net/npm/dynamsoft-barcode-reader@10.4.20/dist/",
+            dce: "https://cdn.jsdelivr.net/npm/dynamsoft-camera-enhancer@4.1.0/dist/",
+          };
 
           // Optional. Used to load wasm resources in advance, reducing latency between video playing and barcode decoding.
           CoreModule.loadWasm(["DBR"]);


### PR DESCRIPTION
`CoreModule.engineResourcePaths.rootDirectory = "https://cdn.jsdelivr.net/npm/";` shows DCE related error on `es6` and `requirejs` sample.

This is a temporary patch to fix the issue.